### PR TITLE
Add missing vuetify dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "vue": "^2.4.4",
-    "vuedraggable": "^2.14.1"
+    "vuedraggable": "^2.14.1",
+    "vuetify": "^1.1.4"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Fixes #2, if vuetify is not installed globally, this fails to compile.